### PR TITLE
Set open-pull-requests-limit to zero

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: pip
     directory: "/"
+    open-pull-requests-limit: 0 # Zero PRs means that only security updates will be triggered
     schedule:
       interval: weekly
       day: monday
@@ -10,6 +11,7 @@ updates:
 
   - package-ecosystem: docker
     directory: "/docker/web"
+    open-pull-requests-limit: 0 # Zero PRs means that only security updates will be triggered
     schedule:
       interval: weekly
       day: monday
@@ -17,6 +19,7 @@ updates:
       - "uxio0"
 
   - package-ecosystem: github-actions
+    open-pull-requests-limit: 0 # Zero PRs means that only security updates will be triggered
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
From now on we are only going to enable security updates to this repo.

The documentation regarding this feature is a bit confusing but according to https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/about-dependabot-security-updates

> The Dependabot security updates feature is available for repositories where you have enabled the dependency graph and Dependabot alerts. You will see a Dependabot alert for every vulnerable dependency identified in your full dependency graph. However, security updates are triggered only for dependencies that are specified in a manifest or lock file. 

This leads me to believe that we still need the `dependabot` configuration to have the security updates enabled. 

Also according to https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit

> This option has no impact on security updates, which have a separate, internal limit of ten open pull requests.

So setting it to zero should have no impact on the security updates.


@gnosis/safe-services
