### PR TITLE
Revert jsonschema to version 3.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ factory-boy==3.2.0
 firebase-admin==5.0.3
 gnosis-py[django]==3.5.3
 gunicorn[gevent]==20.1.0
-jsonschema==4.1.2
+jsonschema==3.2.0
 psycopg2-binary==2.9.1
 redis==3.5.3
 requests==2.26.0


### PR DESCRIPTION
- `jsonschema 4.1.2` is incompatible with `web3 5.24.0` so the dependency was reverted 

@gnosis/safe-services
