### PR TITLE
Fix Dockerfile path in Github Action

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -107,6 +107,7 @@ jobs:
       with:
         context: .
         push: true
+        file: docker/web/Dockerfile
         tags: gnosispm/safe-notification-service:${{ env.DOCKER_TAG }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new


### PR DESCRIPTION
- `build-push-action` by default looks into `{context}/Dockerfile`. However the `Dockerfile` for this repo is in `docker/web/Dockerfile`